### PR TITLE
fix: install ESLint rules that we depend on

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
   "scripts": {
     "test": "mocha tests --recursive"
   },
+  "dependencies": {
+    "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-security": "1.4.0"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",


### PR DESCRIPTION
Out of box, users are met with error messages similar to below:

```
ERR! Oops! Something went wrong! :(
ERR!
ERR! ESLint: 8.4.1
ERR!
ERR! ESLint couldn't find the plugin "eslint-plugin-node".
```

This ESLint plugin should work out of box, and not require adopters to install additional dependencies. We probably need to add more packages here, but our setup already had a few from before so I don't know what else is missing.
