### PR TITLE
Fix: no-document-write should catch newWindow.document.write

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -28,23 +28,18 @@ module.exports = {
     getFullTypeChecker(context) {
         return this.hasFullTypeInformation(context) ? context.parserServices.program.getTypeChecker() : null;
     },
-    getNodeType(node, context) {
-        const typeChecker = context.parserServices.program.getTypeChecker();
-        const tsNode = context.parserServices.esTreeNodeToTSNodeMap.get(node);
-        const tsType = typeChecker.getTypeAtLocation(tsNode);
-        return typeChecker.typeToString(tsType);
-    },
-    getCallerType(fullTypeChecker, object, context){
-        const tsNode = context.parserServices.esTreeNodeToTSNodeMap.get(object);
-        const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
-        const type = fullTypeChecker.typeToString(tsType);
-        return type;
+    getNodeTypeAsString(fullTypeChecker, node, context) {
+        if (fullTypeChecker && node) {
+          const tsNode = context.parserServices.esTreeNodeToTSNodeMap.get(node);
+          const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
+          const type = fullTypeChecker.typeToString(tsType);
+          return type;
+        }
+        return "any";
     },
     isDocumentObject(node, context, fullTypeChecker) {
         if (fullTypeChecker) {
-            const tsNode = context.parserServices.esTreeNodeToTSNodeMap.get(node);
-            const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
-            const type = fullTypeChecker.typeToString(tsType);
+            const type = this.getNodeTypeAsString(fullTypeChecker, node, context);
             return (type === "Document");
         }
 
@@ -58,7 +53,8 @@ module.exports = {
                     node.property != undefined &&
                     node.property.name == "document" && (
                         (node.object != undefined &&
-                        node.object.name == "window") ||
+                         typeof node.object.name === "string" &&
+                         node.object.name.toLowerCase().endsWith('window')) ||
                         (
                             node.object != undefined &&
                             node.object.property != undefined &&

--- a/lib/rules/no-inner-html.js
+++ b/lib/rules/no-inner-html.js
@@ -30,18 +30,8 @@ module.exports = {
   create: function (context) {
     const fullTypeChecker = astUtils.getFullTypeChecker(context);
 
-    function getNodeTypeAsString(node) {
-      if (fullTypeChecker && node) {
-        const tsNode = context.parserServices.esTreeNodeToTSNodeMap.get(node);
-        const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
-        const type = fullTypeChecker.typeToString(tsType);
-        return type;
-      }
-      return "any";
-    }
-
     function mightBeHTMLElement(node) {
-      const type = getNodeTypeAsString(node);
+      const type = astUtils.getNodeTypeAsString(fullTypeChecker, node, context);
       return type.match(/HTML.*Element/) || type === "any";
     }
 

--- a/lib/rules/no-insecure-random.js
+++ b/lib/rules/no-insecure-random.js
@@ -47,7 +47,7 @@ module.exports = {
         var notFalsePositive = false;
 
         if (fullTypeChecker) {
-          const type = astUtils.getCallerType(fullTypeChecker, node.object, context);
+          const type = astUtils.getNodeTypeAsString(fullTypeChecker, node.object, context);
           notFalsePositive = type === "any" || type === "Crypto";
         }else{
           notFalsePositive = node.object.name === 'crypto';
@@ -63,7 +63,7 @@ module.exports = {
       "CallExpression > MemberExpression[property.name='random']"(node) {
         var notFalsePositive = false;
         if (fullTypeChecker) {
-          const type = astUtils.getCallerType(fullTypeChecker, node.object, context);
+          const type = astUtils.getNodeTypeAsString(fullTypeChecker, node.object, context);
           notFalsePositive = type === "any" || type === "Math";
         }else{
           notFalsePositive = node.object.name === 'Math';

--- a/tests/lib/rules/no-document-domain.js
+++ b/tests/lib/rules/no-document-domain.js
@@ -47,6 +47,7 @@ function main() {
 var somevalue = 'somevalue'; 
 document.domain = somevalue;
 window.document.domain = somevalue;
+newWindow.document.domain = somevalue;
       `,
       errors: [
         { 
@@ -56,6 +57,10 @@ window.document.domain = somevalue;
         {
           line: 4,
           messageId: "default" 
+        },
+        {
+          line: 5,
+          messageId: "default"
         }
       ]
     }

--- a/tests/lib/rules/no-document-write.js
+++ b/tests/lib/rules/no-document-write.js
@@ -74,12 +74,16 @@ ruleTester.run(ruleId, rule, {
         document.writeln('...');
         window.document.write('...');
         window.document.writeln('...');
+        newWindow.document.write('...');
+        newWindow.document.writeln('...');
       `,
       errors: [
         { messageId: "default", line: 2 },
         { messageId: "default", line: 3 },
         { messageId: "default", line: 4 },
-        { messageId: "default", line: 5 }
+        { messageId: "default", line: 5 },
+        { messageId: "default", line: 6 },
+        { messageId: "default", line: 7 }
       ]
     }
   ]


### PR DESCRIPTION
This PR fixes false negative we are seeing in our codebases when full type information is not available. I'd like the plugin to be less strict and start catching cases such as `newWindow.document.write()`. Plus minor refactoring in ast-utils. 