### PR TITLE
Allow XML namespaces for XHTML and SVG by default

### DIFF
--- a/lib/rules/no-insecure-url.js
+++ b/lib/rules/no-insecure-url.js
@@ -17,7 +17,10 @@ const DEFAULT_BLOCKLIST = [
 const DEFAULT_EXCEPTIONS = [     // TODO: add more typical false positives such as XML schemas after more testing
     /^http:(\/\/|\\u002f\\u002f)schemas\.microsoft\.com(\/\/|\\u002f\\u002f)?.*/i,
     /^http:(\/\/|\\u002f\\u002f)schemas\.openxmlformats\.org(\/\/|\\u002f\\u002f)?.*/i,
-    /^http:(\/|\\u002f){2}localhost(:|\/|\\u002f)*/i
+    /^http:(\/|\\u002f){2}localhost(:|\/|\\u002f)*/i,
+    /^http:(\/|\\u002f){2}localhost(:|\/|\\u002f)*/i,
+    /^http:(\/\/)www\.w3\.org\/1999\/xhtml/i,
+    /^http:(\/\/)www\.w3\.org\/2000\/svg/i
 ];
 
 module.exports = {

--- a/tests/lib/rules/no-insecure-url.js
+++ b/tests/lib/rules/no-insecure-url.js
@@ -72,12 +72,19 @@ ruleTester.run(ruleId, rule, {
             parserOptions: testUtils.tsReactParserOptions,
         },
         {
-            // should allow xml namespaces, as they are not accessed by the browser
+            // should allow localhost
             code: `
-                var x = "http://localhost/test"
-                var y = "http://localhost"
+                var x = "http://localhost/test";
+                var y = "http://localhost";
             `
-        }
+        },
+        {
+            // should allow xml namespaces for XHTML and SVG even if outside of jsx xmlns attribute
+            code: `
+                var x = "http://www.w3.org/1999/xhtml";
+                var y = "http://www.w3.org/2000/svg";
+            `
+        },
     ],
     invalid: [
         {   // should ban http,ftp strings in variables
@@ -154,7 +161,7 @@ ruleTester.run(ruleId, rule, {
             code: `
                 const someSvg: React.FC = () => {
                     return (
-                        <svg someOtherAttribute="http://www.w3.org/2000/svg">
+                        <svg someOtherAttribute="http://ban-example.com/">
                         </svg>
                     );
                 };


### PR DESCRIPTION
This patch adds default exceptions and adds tests for the following URLs
- http://www.w3.org/1999/xhtml
- http://www.w3.org/2000/svg

Some tests were added and modified to ensure it works as intended.
