### PR TITLE
Enable JSX support for "react/no-danger" to work properly

### DIFF
--- a/config/react.js
+++ b/config/react.js
@@ -8,6 +8,11 @@
 "use strict";
 
 module.exports = {
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
   plugins: [
     "react",
     "@microsoft/sdl"


### PR DESCRIPTION
Hi,

`config/react.js` leverages [react/no-danger](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md), which is a rule to prevent usage of dangerous JSX properties.

Therefore, this patch enables JSX support in the `parserOptions` for `react/no-danger` to work properly.

Cheers,
Zhihui