### PR TITLE
Add adjusted test and new auto fixer for 'no-insecure-url'

### DIFF
--- a/docs/rules/no-insecure-url.md
+++ b/docs/rules/no-insecure-url.md
@@ -6,9 +6,10 @@ Insecure protocols such as [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transf
 - [Rule Test](../../tests/lib/rules/no-insecure-url.js)
 
 ## Options
-This rule comes with two [default lists](../../lib/rules/no-insecure-url.js#L13):
+This rule comes with three [default lists](../../lib/rules/no-insecure-url.js#L13):
 - **blocklist** - a RegEx list of insecure URL patterns.
 - **exceptions** - a RegEx list of common false positive patterns. For example, HTTP URLs to XML schemas are usually allowed as they are used as identifiers, not for establishing actual network connections.
+- **varExceptions** - a RegEx list of false positive patterns which a derivated from the variable name. For example, a variable that is called "insecureURL" which is used to test HTTP explicitly.
 
 These lists can be overrided by providing options.
 
@@ -17,7 +18,8 @@ For example, providing these options... :
 ```javascript
 "@microsoft/sdl/no-insecure-url": ["error", {
             "blocklist": ["^(http|ftp):\\/\\/", "^https:\\/\\/www\\.disallow-example\\.com"],
-            "exceptions": ["^http:\\/\\/schemas\\.microsoft\\.com\\/\\/?.*"]
+            "exceptions": ["^http:\\/\\/schemas\\.microsoft\\.com\\/\\/?.*"],
+            "varExceptions": ["insecure?.*"]
         }]
 ```
 
@@ -30,7 +32,11 @@ For example, providing these options... :
 - `http://schemas.microsoft.com`
   - `http://schemas.microsoft.com/sharepoint`
   - `http://schemas.microsoft.com/path/subpath`
-  - ...
+
+... and also overrides the internal variable exceptions list, allowing the following declaration name patterns as exceptions.:
+- `var insecureURL = "http://..."`
+- `var insecureWebsite = "http://..."`
+- ...
 
 URLs in neither the blocklist nor the exceptions list, are allowed:
 - `telnet://`...

--- a/lib/rules/no-insecure-url.js
+++ b/lib/rules/no-insecure-url.js
@@ -18,14 +18,16 @@ const DEFAULT_EXCEPTIONS = [     // TODO: add more typical false positives such 
     /^http:(\/\/|\\u002f\\u002f)schemas\.microsoft\.com(\/\/|\\u002f\\u002f)?.*/i,
     /^http:(\/\/|\\u002f\\u002f)schemas\.openxmlformats\.org(\/\/|\\u002f\\u002f)?.*/i,
     /^http:(\/|\\u002f){2}localhost(:|\/|\\u002f)*/i,
-    /^http:(\/|\\u002f){2}localhost(:|\/|\\u002f)*/i,
     /^http:(\/\/)www\.w3\.org\/1999\/xhtml/i,
     /^http:(\/\/)www\.w3\.org\/2000\/svg/i
 ];
 
+const DEFAULT_VARIABLES_EXECEPTIONS = [];
+
 module.exports = {
     defaultBlocklist: DEFAULT_BLOCKLIST,
     defaultExceptions: DEFAULT_EXCEPTIONS,
+    defaultVarExecptions: DEFAULT_VARIABLES_EXECEPTIONS,
     meta: {
         type: "suggestion",
         fixable: "code",
@@ -45,6 +47,12 @@ module.exports = {
                             type: "string"
                         }
                     },
+                    varExceptions: {
+                      type: "array",
+                      items: {
+                          type: "string"
+                      }
+                  },
                 },
                 additionalProperties: false
             }
@@ -62,9 +70,20 @@ module.exports = {
         const options = context.options[0] || {};
         const blocklist = (options.blocklist || DEFAULT_BLOCKLIST).map((pattern) => { return new RegExp(pattern, "i"); });
         const exceptions = (options.exceptions || DEFAULT_EXCEPTIONS).map((pattern) => { return new RegExp(pattern, "i"); });
+        const varExceptions = (options.varExceptions || DEFAULT_VARIABLES_EXECEPTIONS).map((pattern) => { return new RegExp(pattern, "i"); });
 
         function matches(patterns, value) {
             return patterns.find((re) => { return re.test(value) }) !== undefined;
+        }
+
+        function shouldFix( varExceptions,context, node) {
+          let sourceCode = context.getSourceCode();
+          // check variable for unfixable pattern e.g. `var insecureURL = "http://..."`
+          let text = node.parent
+            ? sourceCode.getText(node.parent)
+            : sourceCode.getText(node);
+          // if no match, fix the line
+          return !matches(varExceptions,text);
         }
 
         return {
@@ -75,11 +94,19 @@ module.exports = {
                     {
                         // Do nothing
                     }
-                    else if (matches(blocklist, node.value) && !matches(exceptions, node.value)) {
-                        context.report({
-                            node: node,
-                            messageId: "doNotUseInsecureUrl"
-                        });
+                    else if (matches(blocklist, node.value) && !matches(exceptions, node.value) && shouldFix(varExceptions,context, node)) {
+                      context.report({
+                        node: node,
+                        messageId: "doNotUseInsecureUrl",
+                        fix(fixer) {
+                          // Only fix if it contains an http url
+                          if (node.value.toLowerCase().includes("http")) {
+                            let fixedString = node.value.replace(/http:/i, "https:");
+                            //insert an "s" before ":/" to change http:/ to https:/
+                            return fixer.replaceText(node, JSON.stringify(fixedString));
+                          }
+                        },
+                      });
                     }
                 }
             },
@@ -88,15 +115,26 @@ module.exports = {
                     const rawStringText = node.value.raw;
                     const cookedStringText = node.value.cooked;
 
-                    if ((matches(blocklist, rawStringText) && !matches(exceptions, rawStringText)) ||
-                        (matches(blocklist, cookedStringText) && !matches(exceptions, cookedStringText))) {
-                        context.report({
-                            node: node,
-                            messageId: "doNotUseInsecureUrl"
-                        });
-                    }
-                }
-            }
+                  if (shouldFix(varExceptions,context, node) && (matches(blocklist, rawStringText) && !matches(exceptions, rawStringText)) ||
+                      (matches(blocklist, cookedStringText) && !matches(exceptions, cookedStringText))) {
+                      context.report({
+                        node: node,
+                        messageId: "doNotUseInsecureUrl",
+                        fix(fixer) {
+                          // Only fix if it contains an http url
+                          if (node.value.raw.toLowerCase().includes("http")) {
+                            let escapedString =  JSON.stringify(context.getSourceCode().getText(node));
+                            // delete "" that JSON.stringify created and convert to `` string
+                            escapedString = ``+ escapedString.substring(1, escapedString.length-1);
+                            let fixedString = escapedString.replace(/http:/i, "https:");
+                            //insert an "s" before ":/" to change http:/ to https:/
+                            return fixer.replaceText(node, fixedString);
+                          }
+                        }
+                      });
+                  }
+              }
+            },
         };
     },
 };


### PR DESCRIPTION
### Goal of this patch
* introducing a `--fix` option for `no-insecure-url` (only for `http://` but could be extended to fix also `ftp` and `ws`)
* introducing an exception list for vairable names

### Changes
* removed one duplicate in `DEFAUL_EXCEPTIONS`
* lines for `--fix` option: 
There are two fixers. The first for the Literals is escaping the string, replaces `http` by `https` and write it back in the related line.
```javascript
   fix(fixer) {
      // Only fix if it contains an http url
      if (node.value.toLowerCase().includes("http")) {
        let fixedString = node.value.replace(/http:/i, "https:");
        //insert an "s" before ":/" to change http:/ to https:/
        return fixer.replaceText(node, JSON.stringify(fixedString));
      }
    },
``` 
The second one is for TemplateElements. It escapes the string, then removes the "" that `JSON.stringify` created, replace `http` by `https` in the correct manner (in backticks) and write it back into the related line.
```javascript
 fix(fixer) {
  // Only fix if it contains an http url
  if (node.value.raw.toLowerCase().includes("http")) {
      let escapedString =  JSON.stringify(context.getSourceCode().getText(node));
      // delete "" that JSON.stringify created and convert to `` string
      escapedString = ``+ escapedString.substring(1, escapedString.length-1);
      let fixedString = escapedString.replace(/http:/i, "https:");
      //insert an "s" before ":/" to change http:/ to https:/
      return fixer.replaceText(node, fixedString);
    }
  }
``` 

* introduce `shoudlFix()` function
```javascript
        function shouldFix( varExceptions,context, node) {
          let sourceCode = context.getSourceCode();
          // check variable for unfixable pattern e.g. `var insecureURL = "http://..."`
          let text = node.parent
            ? sourceCode.getText(node.parent)
            : sourceCode.getText(node);
          // if no match, fix the line
          return !matches(varExceptions,text);
        }
``` 
which checks if a line should get exempted from linter because it includes a variable name that shouldn't get upgraded.
* added test for auto-fixer (string escaping, backtick strings and both combined)
* added `output:` to each test that gets affected by auto-fixer
* added test for the new introduced variable exception list for variables
* adjusted `README` file of `no-insecure-url` to include new exception list