### PR TITLE
Update node-version-integration.yml

### DIFF
--- a/.github/workflows/node-version-integration.yml
+++ b/.github/workflows/node-version-integration.yml
@@ -6,7 +6,7 @@ name: Node CI
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main, release/vNext]
 
 jobs:


### PR DESCRIPTION
Previously, this workflow would run on the base branch (e.g, `main` in this repo) instead of the head branch (e.g, User/Fork:PR-branch)