### PR TITLE
Update eslint-plugin-react to be compatible with eslint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/eslint-plugin-sdl",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "ESLint plugin focused on common security issues and misconfigurations discoverable during static testing as part of Microsoft Security Development Lifecycle (SDL)",
   "keywords": [
     "eslint",


### PR DESCRIPTION
As far as I can tell this change should be backwards compatible, as eslint-plugin-react has a very loose dependency on eslint.