### PR TITLE
Update eslint-plugin-react to be compatible with eslint v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/eslint-plugin-sdl",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "ESLint plugin focused on common security issues and misconfigurations discoverable during static testing as part of Microsoft Security Development Lifecycle (SDL)",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "mocha": "^8.3.2",
     "typescript": "^3.9.7"
   },
+  "peerDependencies": {
+    "eslint": "^4.19.1 || ^5 || ^6 || ^7 || ^8"
+  },
   "engines": {
     "node": ">=0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   "dependencies": {
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-security": "1.4.0",
-    "eslint-plugin-react": "7.24.0"
+    "eslint-plugin-react": "7.33.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
-    "eslint": "^7.32.0",
+    "eslint": "^7.32.0 || ^8",
     "mocha": "^8.3.2",
     "typescript": "^3.9.7"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
-    "eslint": "^7.32.0 || ^8",
+    "eslint": "^7.32.0",
     "mocha": "^8.3.2",
     "typescript": "^3.9.7"
   },


### PR DESCRIPTION
As far as I can tell this change is backwards compatible, as eslint-plugin-react has a wide list of allowed eslint versions