### PR TITLE
Add peer dependency on eslint to properly satisfy plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "mocha": "^8.3.2",
     "typescript": "^3.9.7"
   },
+  "peerDependencies": {
+    "eslint": "^4.19.1 || ^5 || ^6 || ^7"
+  },
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
At the moment, the plugin depends on `eslint-plugin-` `node`/`security`/`react` directly, and `es` implicitly via `node`, but they all publish peer dependencies on `eslint`.

The plugin should also expose `eslint` as a peer dependency itself for the reasons listed at [Implicit transitive peer dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0). 

`yarn` will currently issue warnings when using `@microsoft/eslint-plugin-sdl` because of the unmet peer dependency.

Setting at `^4.19.1 || ^5 || ^6 || ^7` to reflect the current dependencies:
 - `eslint-plugin-react@npm:7.24.0 → ^3 || ^4 || ^5 || ^6 || ^7`
 - `eslint-plugin-node@npm:11.1.0 → >=5.16.0`
 - `eslint-plugin-es@npm:3.0.1 → >=4.19.1`

More current versions of `react` added support for ESLint 8, which I'd suggest the plugin should move to support.