### PR TITLE
Run e2e tests with ESLint v8

### DIFF
--- a/.github/workflows/E2E integration.yml
+++ b/.github/workflows/E2E integration.yml
@@ -48,7 +48,7 @@ jobs:
           
       - name: Install eslint for discord library and eslint-plugin-dependencies
         run: |
-          npm i eslint
+          npm i eslint@8
           npm i eslint-plugin-security
           npm i eslint-plugin-react
           npm i eslint-plugin-node


### PR DESCRIPTION
Run ESLint v8 to make integration tests pass https://github.com/microsoft/eslint-plugin-sdl/actions/runs/10958190746/job/30427898621 (will be updated once v9 gets merged)