### PR TITLE
configs.typescript returns typescript instead of react

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ plugin.configs["common"] = require("../config/common")(plugin);
 plugin.configs["electron"] = require("../config/electron")(plugin);
 plugin.configs["node"] = require("../config/node")(plugin);
 plugin.configs["react"] = require("../config/react")(plugin);
-plugin.configs["typescript"] = require("../config/react")(plugin);
+plugin.configs["typescript"] = require("../config/typescript")(plugin);
 
 plugin.configs["required"] = [
   ...plugin.configs["angular"],


### PR DESCRIPTION
Not sure if this was intended, but it seemed like a wrong export.

Please keep in mind that this will also change the way of `configs.recommended` is working, as this is also using `plugins.configs["typescript"]` (which was actually `react` before).