### PR TITLE
Fix a few issues with some rules we noticed when migrating to flat config

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -7,6 +7,8 @@
 
 "use strict";
 
+const path = require("path");
+
 module.exports = {
   isTypeScriptParserServices(parserServices) {
     // Check properties specific to @typescript-eslint/parser
@@ -38,6 +40,15 @@ module.exports = {
       return type;
     }
     return "any";
+  },
+  hasDeclarationInFile(type, fileName) {
+    const symbol = type.getSymbol();
+    return Boolean(
+      symbol &&
+        symbol
+          .getDeclarations()
+          ?.some((declaration) => path.basename(declaration.getSourceFile().fileName) === fileName)
+    );
   },
   isDocumentObject(node, context, fullTypeChecker) {
     if (fullTypeChecker) {

--- a/lib/rules/no-inner-html.js
+++ b/lib/rules/no-inner-html.js
@@ -30,7 +30,7 @@ module.exports = {
 
     function mightBeHTMLElement(node) {
       const type = astUtils.getNodeTypeAsString(fullTypeChecker, node, context);
-      return type.match(/HTML.*Element/) || type === "any";
+      return type.match(/HTML.*Element/) || type === "any" || type == "Element";
     }
 
     return {

--- a/lib/rules/no-inner-html.js
+++ b/lib/rules/no-inner-html.js
@@ -8,7 +8,21 @@
 
 "use strict";
 
+const path = require("path");
 const astUtils = require("../ast-utils");
+
+function isDomElement(type) {
+  const symbol = type.getSymbol();
+  // A local type can also be named Element, so only trust the DOM library declaration.
+  return (
+    symbol &&
+    symbol
+      .getDeclarations()
+      ?.some(
+        (declaration) => path.basename(declaration.getSourceFile().fileName) === "lib.dom.d.ts"
+      )
+  );
+}
 
 module.exports = {
   meta: {
@@ -29,8 +43,18 @@ module.exports = {
     const fullTypeChecker = astUtils.getFullTypeChecker(context);
 
     function mightBeHTMLElement(node) {
-      const type = astUtils.getNodeTypeAsString(fullTypeChecker, node, context);
-      return type.match(/HTML.*Element/) || type === "any" || type == "Element";
+      if (!fullTypeChecker) {
+        return true;
+      }
+
+      const tsNode = context.sourceCode.parserServices.esTreeNodeToTSNodeMap.get(node);
+      const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
+      const type = fullTypeChecker.typeToString(tsType);
+      return (
+        type.match(/HTML.*Element/) ||
+        type === "any" ||
+        (type === "Element" && isDomElement(tsType))
+      );
     }
 
     return {

--- a/lib/rules/no-inner-html.js
+++ b/lib/rules/no-inner-html.js
@@ -8,21 +8,7 @@
 
 "use strict";
 
-const path = require("path");
 const astUtils = require("../ast-utils");
-
-function isDomElement(type) {
-  const symbol = type.getSymbol();
-  // A local type can also be named Element, so only trust the DOM library declaration.
-  return (
-    symbol &&
-    symbol
-      .getDeclarations()
-      ?.some(
-        (declaration) => path.basename(declaration.getSourceFile().fileName) === "lib.dom.d.ts"
-      )
-  );
-}
 
 module.exports = {
   meta: {
@@ -53,7 +39,8 @@ module.exports = {
       return (
         type.match(/HTML.*Element/) ||
         type === "any" ||
-        (type === "Element" && isDomElement(tsType))
+        // A local type can also be named Element, so only trust the DOM library declaration.
+        (type === "Element" && astUtils.hasDeclarationInFile(tsType, "lib.dom.d.ts"))
       );
     }
 

--- a/lib/rules/no-postmessage-star-origin.js
+++ b/lib/rules/no-postmessage-star-origin.js
@@ -9,6 +9,10 @@
 
 const astUtils = require("../ast-utils");
 
+function isWindowOrAny(type) {
+  return type === "any" || type === "Window";
+}
+
 module.exports = {
   meta: {
     type: "suggestion",
@@ -41,7 +45,16 @@ module.exports = {
           );
           const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
           const type = fullTypeChecker.typeToString(tsType);
-          if (type !== "any" && type !== "Window") {
+          if (!isWindowOrAny(type)) {
+            return;
+          }
+
+          if (
+            tsType.isUnion() &&
+            tsType.types
+              .map((value) => fullTypeChecker.typeToString(value))
+              .every((t) => !isWindowOrAny(t))
+          ) {
             return;
           }
         }

--- a/lib/rules/no-postmessage-star-origin.js
+++ b/lib/rules/no-postmessage-star-origin.js
@@ -45,19 +45,15 @@ module.exports = {
           );
           const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
           const type = fullTypeChecker.typeToString(tsType);
-          if (!isWindowOrAny(type)) {
+          // Remove some false positives by returning if the type does not contain Union
+          if (tsType.isUnionOrIntersection()) {
+            if (tsType.types.every(t=> !isWindowOrAny(fullTypeChecker.typeToString(t)))) {
+              return;
+            }
+          } else if(!isWindowOrAny(type)){
             return;
           }
 
-          if (
-            tsType.isUnion() &&
-            tsType.types
-              .map((value) => fullTypeChecker.typeToString(value))
-              .every((t) => !isWindowOrAny(t))
-          ) {
-            return;
-          }
-        }
 
         context.report({
           node: node,

--- a/lib/rules/no-postmessage-star-origin.js
+++ b/lib/rules/no-postmessage-star-origin.js
@@ -9,8 +9,13 @@
 
 const astUtils = require("../ast-utils");
 
-function isWindowOrAny(type) {
-  return type === "any" || type === "Window";
+function isWindowOrAny(fullTypeChecker, type) {
+  const typeName = fullTypeChecker.typeToString(type);
+  return (
+    typeName === "any" ||
+    // A local type can also be named Window, so only trust the DOM library declaration.
+    (typeName === "Window" && astUtils.hasDeclarationInFile(type, "lib.dom.d.ts"))
+  );
 }
 
 module.exports = {
@@ -44,13 +49,12 @@ module.exports = {
             node.callee.object
           );
           const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
-          const type = fullTypeChecker.typeToString(tsType);
           // Unions such as Window | null must be checked one constituent at a time.
           if (tsType.isUnionOrIntersection()) {
-            if (tsType.types.every((t) => !isWindowOrAny(fullTypeChecker.typeToString(t)))) {
+            if (tsType.types.every((t) => !isWindowOrAny(fullTypeChecker, t))) {
               return;
             }
-          } else if (!isWindowOrAny(type)) {
+          } else if (!isWindowOrAny(fullTypeChecker, tsType)) {
             return;
           }
         }

--- a/lib/rules/no-postmessage-star-origin.js
+++ b/lib/rules/no-postmessage-star-origin.js
@@ -45,7 +45,7 @@ module.exports = {
           );
           const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
           const type = fullTypeChecker.typeToString(tsType);
-          // Remove some false positives by returning if the type does not contain Window or any
+          // Unions such as Window | null must be checked one constituent at a time.
           if (tsType.isUnionOrIntersection()) {
             if (tsType.types.every((t) => !isWindowOrAny(fullTypeChecker.typeToString(t)))) {
               return;

--- a/lib/rules/no-postmessage-star-origin.js
+++ b/lib/rules/no-postmessage-star-origin.js
@@ -45,15 +45,15 @@ module.exports = {
           );
           const tsType = fullTypeChecker.getTypeAtLocation(tsNode);
           const type = fullTypeChecker.typeToString(tsType);
-          // Remove some false positives by returning if the type does not contain Union
+          // Remove some false positives by returning if the type does not contain Window or any
           if (tsType.isUnionOrIntersection()) {
-            if (tsType.types.every(t=> !isWindowOrAny(fullTypeChecker.typeToString(t)))) {
+            if (tsType.types.every((t) => !isWindowOrAny(fullTypeChecker.typeToString(t)))) {
               return;
             }
-          } else if(!isWindowOrAny(type)){
+          } else if (!isWindowOrAny(type)) {
             return;
           }
-
+        }
 
         context.report({
           node: node,

--- a/tests/fixtures/ts/tsconfig.json
+++ b/tests/fixtures/ts/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  "compilerOptions": {
+    "strictNullChecks": true
+  },
   "include": ["estree.ts"]
 }

--- a/tests/lib/rules/no-inner-html.js
+++ b/tests/lib/rules/no-inner-html.js
@@ -30,6 +30,18 @@ ruleTester.run(ruleId, rule, {
         test.innerHTML = test;
         test.outerHTML = test;
       `
+    },
+    {
+      languageOptions: testUtils.tsLanguageOptions,
+      code: `
+        function main() {
+          class Element {
+            innerHTML = "";
+          }
+          const element = new Element();
+          element.innerHTML = "test";
+        }
+      `
     }
   ],
   invalid: [
@@ -47,6 +59,15 @@ ruleTester.run(ruleId, rule, {
         { messageId: "noInnerHtml", line: 4 },
         { messageId: "noInsertAdjacentHTML", line: 5 }
       ]
+    },
+    {
+      languageOptions: testUtils.tsLanguageOptions,
+      code: `
+        function main(element: Element) {
+          element.innerHTML = "test";
+        }
+      `,
+      errors: [{ messageId: "noInnerHtml", line: 3 }]
     },
     {
       code: `

--- a/tests/lib/rules/no-postmessage-star-origin.js
+++ b/tests/lib/rules/no-postmessage-star-origin.js
@@ -28,6 +28,19 @@ function main() {
   w.postMessage('test', '*');
 }
       `
+    },
+    {
+      languageOptions: testUtils.tsLanguageOptions,
+      code: `
+function main() {
+  class Window {
+    postMessage(): void {
+    };
+  }
+  const target = new Window();
+  target.postMessage('test', '*');
+}
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-postmessage-star-origin.js
+++ b/tests/lib/rules/no-postmessage-star-origin.js
@@ -52,6 +52,14 @@ function main() {
         { messageId: "default", line: 2 },
         { messageId: "default", line: 4 }
       ]
+    },
+    {
+      languageOptions: testUtils.tsLanguageOptions,
+      code: `
+        declare const target: Window | null;
+        target.postMessage(message, "*");
+      `,
+      errors: [{ messageId: "default", line: 3 }]
     }
   ]
 });


### PR DESCRIPTION
I work on an internal repo at Microsoft that uses these rules. We noticed that when upgrading to eslint flat config that some eslint errors were no longer firing. After some debugging we found that the following issues issues:

* When type of an object was Window | null, no-postmessage-star-origin did not report it as an error
* When the type of an HTML element was just "Element" no-inner-html didn't fire.