### PR TITLE
Fixed typos in package name @ README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Plugin is intended as a baseline for projects that follow [Microsoft Security De
 ## Installation
 
 ```sh
-npm install microsoft/eslint-plugin-sdl
+npm install @microsoft/eslint-plugin-sdl
 ```
 
 or
 
 ```sh
-yarn add microsoft/eslint-plugin-sdl
+yarn add @microsoft/eslint-plugin-sdl
 ```
 
 ## Configs


### PR DESCRIPTION
The README was saying to install `microsoft/eslint-plugin-sdl` (without `@` prefix), https://www.npmjs.com/package/microsoft/eslint-plugin-sdl doesn't exist, https://www.npmjs.com/package/@microsoft/eslint-plugin-sdl does.